### PR TITLE
Notification::closeReason() must have const qualifier.

### DIFF
--- a/src/libsnore/notification/notification.cpp
+++ b/src/libsnore/notification/notification.cpp
@@ -127,7 +127,7 @@ const QHash<int, Action> &Notification::actions() const
     return d->m_actions;
 }
 
-const Notification::CloseReasons &Notification::closeReason()
+const Notification::CloseReasons &Notification::closeReason() const
 {
     return d->m_closeReason;
 }

--- a/src/libsnore/notification/notification.h
+++ b/src/libsnore/notification/notification.h
@@ -228,7 +228,7 @@ public:
      *
      * @return the close reason
      */
-    const Notification::CloseReasons &closeReason();
+    const Notification::CloseReasons &closeReason() const;
 
     /**
      * Returns notification specific hints.


### PR DESCRIPTION
In a slot connected to `Snore::SnoreCore::notificationClosed` signal, we can't access `closeReason()` method, because it has no const qualifier.